### PR TITLE
Add CardInfo test suite

### DIFF
--- a/NearTests/CardInfoTests.swift
+++ b/NearTests/CardInfoTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import Near
+
+final class CardInfoTests: XCTestCase {
+    func testGetCardDataReturnsThreeItemsForEachTab() {
+        for tab in Tab.allCases {
+            let data = getCardData(for: tab)
+            XCTAssertEqual(data.count, 3, "Tab \(tab) should have 3 items")
+        }
+    }
+
+    func testFirstFoodItemMatchesExpected() {
+        let items = getCardData(for: .food)
+        guard let first = items.first else {
+            XCTFail("Expected at least one item")
+            return
+        }
+        XCTAssertEqual(first.title, "Pizza Bar La Strada")
+        XCTAssertEqual(first.category, "Restaurant")
+    }
+}


### PR DESCRIPTION
## Summary
- add `CardInfoTests` to cover `getCardData` helper

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f61f2d140832fb14d4072506034cf